### PR TITLE
Update Italian language

### DIFF
--- a/lang/Italian.ini
+++ b/lang/Italian.ini
@@ -1,15 +1,17 @@
 // Any lines starting with "//" will not be read.
-// Any lines that have "//" will not read past the "//"
+// Any lines that have "//" will not read past the "//". It's known as a comment, if you didn't know.
 // These are mostly finalized, and if anymore controls get added, you can just add them here
 // This is the internal langauge, so you can use this as a base.
+// I recommend you add your name commented to the top, so people can see who contributed to the translation.
 
-// Italian language v. 02.08.2021 based on template 1.4 (31.07.2021)
-// New additions: GenericSound, GenericVideo, GenericAudio, GenericCustom, frmAbout, lbAboutBody, llbCheckForUpdates, msgBatchDownloadFromFile, frmSettings
-// Removed/Unused: rbVideo, rbAudio, rbCustom, rbConvertAudio, rbConvertVideo, rbConvertCustom
+// Template version 1.41, last update 2021-08-01
+// 1.4 New additions: chkUseSelection, rbVideoSelectionPlaylistIndex, rbVideoSelectionPlaylistItems, rbVideoSelectionOnDate, rbVideoSelectionBeforeDate, rbVideoSelectionAfterDate, txtPlaylistStartHint, txtPlaylistEndHint, txtPlaylistItemsHint, txtVideoDateHint tabDownloadsBatch, chkSettingsDownloadsSeparateBatchDownloads, chkSettingsDownloadsSeparateBatchDownloadsHint, chkSettingsDownloadsAddDateToBatchDownloadFolders, chkSettingsDownloadsAddDateToBatchDownloadFoldersHint, GenericRetry, tabSettingsPortable, lbSettingsPortableInformation, chkSettingsPortableToggleIni, chkSettingsGeneralCheckForBetaUpdates, chkSettingsGeneralCheckForBetaUpdatesHint,
+
+// 1.41 New additions: lbSettingsDownloadsUpdatingYtdlType, cbSettingsDownloadsUpdatingYtdlTypeHint, llbSettingsDownloadsYtdlTypeViewRepo, llbSettingsDownloadsYtdlTypeViewRepoHint, chkSettingsDownloadsDownloadPathUseRelativePathHint
+
+// Italian language v. 05.08.2021
 
 // You can change the "CurrentLanguageVersion" to your own version.
-//
-
 
 [Italiano]
 CurrentLanguageShort=it
@@ -221,10 +223,13 @@ chkSettingsDownloadsForceIpv4=Forza IPv4
 chkSettingsDownloadsForceIpv6=Forza IPv6
 chkSettingsDownloadsUseProxy=Usa un proxy
 chksettingsDownloadsUseYoutubeDlsUpdater=Usa updater interno youtube-dl
+lbSettingsDownloadsUpdatingYtdlType=Fork Youtube-DL
+llbSettingsDownloadsYtdlTypeViewRepo=Visualizza repo sorgenti
 chkSettingsDownloadsSeparateBatchDownloads=Batch download separati
 chkSettingsDownloadsAddDateToBatchDownloadFolders=Includi la data nella cartella download
 
 lbSettingsDownloadsDownloadPathHint=Il percorso della cartella in cui verranno scaricati i file
+chkSettingsDownloadsDownloadPathUseRelativePathHint=Salva nel percorso relativo del programma.\r\n\r\nSe l'opzione è selezionata il programma verificherà il percorso di salvataggio ed userà la cartella attuale come percorso base.\r\nSe vuoi salvatare in qualsiasi punto al di fuori della cartella attuale non impostare il flag e salvaerai nella cartella selezionata.
 lbSettingsDownloadsFileNameSchemaHint=Lo schema del nome file\n\nIn sostanza sostituisce le sequenze con informazioni video per un nome file personalizzato.
 llSettingsDownloadsSchemaHelpHint=Fai clic qui per visualizzare i parametri supportati
 txtSettingsDownloadsFileNameSchemaHint=Lo schema del nome file che verrà usato da youtube-dl
@@ -255,6 +260,8 @@ cbSettingsDownloadsProxyTypeHint=Il protocollo proxy che verrà usato
 txtSettingsDownloadsProxyIpHint=L'IP proxy che verrà usato
 txtSettingsDownloadsProxyPortHint=La porta proxy che verrà usata
 chksettingsDownloadsUseYoutubeDlsUpdaterHint=Usa il programma di aggiornamento interno di youtube-dl invece del programma di aggiornamento di questa applicazione
+cbSettingsDownloadsUpdatingYtdlTypeHint=Il repository youtube-dl che verrà preso di mira
+llbSettingsDownloadsYtdlTypeViewRepoHint=Vai alla pagina del repository del fork selezionato
 chkSettingsDownloadsSeparateBatchDownloadsHint=I donwload batch sono separati in una nuova cartella nel percorso download definito
 chkSettingsDownloadsAddDateToBatchDownloadFoldersHint=I download batch sono ulteriormente separati in una nuova cartella che è la data e l'ora di inizio del batch
 


### PR DESCRIPTION
@murrty 

Italian language update

Please take care about version numbering (before 2.64r4 now 2.261).

Use always progressive numbering scheme. Example

2.26.01
2.26.02
etc
