### PR TITLE
Update Japanese.ini

### DIFF
--- a/Languages/Japanese.ini
+++ b/Languages/Japanese.ini
@@ -452,7 +452,7 @@ lbUpdateAvailableUpdateVersion=最新のバージョン: {0}
 lbUpdateAvailableCurrentVersion=現在のバージョン: {0}
 lbUpdateAvailableChangelog=変更履歴:
 lbUpdateSize=新しい実行ファイルのサイズ {0}
-btnUpdateAvailableSkipVersion=スキップ
+btnUpdateAvailableSkipVersion=この版無視
 btnUpdateAvailableUpdate=更新
 
 frmUpdaterInvalidData=更新データを利用できません

--- a/Languages/Japanese.ini
+++ b/Languages/Japanese.ini
@@ -1,27 +1,10 @@
-// Any lines starting with "//" will not be read.
-// Any lines that have "//" will not read past the "//". It's known as a comment, if you didn't know.
-// These are mostly finalized, and if anymore controls get added, you can just add them here
-// This is the internal langauge, so you can use this as a base.
-// I recommend you add your name commented to the top, so people can see who contributed to the translation.
-// Do note: Exceptions will not be modifiable because I need to be able to read them.
-
-// Template version 1.54, last update 2022-06-20
-
-// New additions:
-//    mClipboardAutoDownload
-//    dlgClipboardAutoDownloadNotice
-//    GenericVerifyLinks
-
-// Changed:
-//    chkBatchDownloadClipboardScanVerifyLinks -> GenericVerifyLinks
-//    BatchDownloadClipboardScannerNotice -> dlgBatchDownloadClipboardScannerNotice
-
-// You can change the "CurrentLanguageVersion" to your own version, or if you're contributing to an already existing one, you can bump up the version one. Or add it as a decimal, if it's a minor fix. Up to you, really.
+// Translators: thr3a (2021), maboroshin (2023), Update: 2023-01-30
+// Template version 3.3.0-1, last update 2022-12-07
 
 [Japanese]
 CurrentLanguageShort=ja-jp
-CurrentLanguageHint=変更するにはここをクリックしてください
-CurrentLanguageVersion=1
+CurrentLanguageHint=変更するにはここをクリック
+CurrentLanguageVersion=3.3.0-1
 
 GenericInputBest=最高
 GenericInputWorst=最低
@@ -30,54 +13,84 @@ GenericSound=音
 GenericVideo=動画
 GenericAudio=音声
 GenericCustom=カスタム
-GenericRetry=リトライ
+GenericRetry=再試行
 GenericStart=開始
 GenericStop=停止
 GenericExit=終了
 GenericOk=OK
 GenericSave=保存
 GenericAdd=追加
+GenericClose=閉じる
+GenericClear=消去
 GenericRemoveSelected=選択項目の削除
-GenericVerifyLinks=コピーしたリンクの検証
+GenericVerifyLinks=コピーしたリンク検証
+GenericDoNotReEncode=(再エンコードしない)
+GenericDoNotRemux=(Remux しない)
+GenericDoNotDownload=(ダウンロードしない)
+GenericUnknownFormat=不明の形式
+GenericMoreInfo=詳細情報
+GenericTitle=タイトル
+GenericLength=長さ
+GenericUploadedOn=アップロード日
 
-dlgFirstTimeInitialMessage=youtube-dl-guiはyoutube-dlの視覚的な拡張機能であり、youtube-dlの開発者とは一切関係ありません。\n\nこのプログラム（および私）は、著作権を所有していない、またはパブリックドメインにないビデオの著作権侵害または違法ダウンロードを容認しません。\n\n（私の管轄区域で）違法なものをダウンロードする際の問題に関するヘルプは無視されます。\n\nこのメッセージは二度と表示されません。\n\n上記を読みましたか？
-dlgFirstTimeDownloadFolder=ダウンロードはデフォルトでダウンロードフォルダに保存されますが、今すぐ別の場所を指定しますか？\n（これはいつでも設定で変更できます）
+frmGenericDownloadProgress=ダウンロード中...
 
-dlgFindDownloadFolder=ダウンロードの保存先フォルダーを選択してください...
+dlgFirstTimeInitialMessage=youtube-dl-gui は youtube-dl の視覚的な拡張機能で、youtube-dl の開発者とは関係ありません。\n\nこのプログラム（および私）は、あなたが著作権を所有しない、またはパブリックドメインでない動画の著作権侵害や違法なダウンロードを容認しません。\n\n（私の管轄区域で）違法なダウンロード時に起こる問題に関する支援の要求は無視します。\n\nこのメッセージは次回は表示されません。\n\n以上をお読みになりましたか？
+dlgFirstTimeDownloadFolder=既定ではダウンロードフォルダにダウンロードされます。今、別の保存場所を指定しますか？\n（設定からいつでも変更できます）
+dlgFirstTimeDownloadYoutubeDl=youtube-dl をダウンロードしますか？今行わなくても設定から手動で行うこともできます。\n\n* yt-dlp を既定の派生ソフトとして使用します。\n* youtube-dl が認識できる場所にあり（このフォルダ、システムパスなど）、更新が利用できればこちらを更新します。
+dlgFirstTimeDownloadFfmpeg=ffmpeg をダウンロードしますか？今行わなくても設定から手動で行うこともできます。\n\n* ffmpeg が認識できる場所にあれば（このフォルダ、システムパスなど）、自動で最新版にします。
 
-dlgClipboardAutoDownloadNotice=Using the clipboard auto downloader will automatically attempt to download verified links from the clipboard using the selected settings on the main form. Please do not copy any sensitive information while this option is enabled, ever.
-dlgBatchDownloadClipboardScannerNotice=Enabling this option will add anything from your clipboard when something is copied (link or not). It will need to be manually enabled per-converter instance. Take care to not copy any sensitive information to the cipboard.
+dlgFindDownloadFolder=ダウンロードの保存先のフォルダーを選択...
 
-dlgMainArgsTxtDoesntExist=args.txt does not exist, create it and put in arguments to use this command
-dlgMainArgsTxtIsEmpty=args.txt is empty, save arguments to the file to use this command
-dlgMainArgsNoneSaved=アプリケーション設定に引数は保存されないため、このコマンドを使用する場合は設定に引数を保存してください。
-dlgConvertSelectFileToConvert=Select a file to convert...
-dlgMergeSelectFileToMerge=Select a file to merge...
-dlgSaveOutputFileAs=Save the output file as...
+dlgClipboardAutoDownloadNotice=クリップボードから自動ダウンロードを使うと、メインのフォームで選択済みの設定を使って、クリップボードから検証されたリンクのダウンロードを自動で試みます。このオプションを有効にしたら、機密情報はコピーしないでください。
+dlgBatchDownloadClipboardScannerNotice=このオプションを有効にしたら、何かがコピーされた時にクリップボードから何かが追加されます（リンクでなくとも）。変換するインスタンスごとに手動で有効にする必要があります。機密情報をクリップボードにコピーしないでください。
+
+dlgMainArgsTxtDoesntExist=args.txt がありません。このコマンドを使うには作成し引数を記入してください
+dlgMainArgsTxtIsEmpty=args.txt が空です。このコマンドを使うには引数をファイルに保存してください
+dlgMainArgsNoneSaved=本アプリの設定に引数は保存されないため、このコマンドを使うには設定に引数を保存してください
+dlgConvertSelectFileToConvert=変換するファイルを選択...
+dlgMergeSelectFileToMerge=結合するファイルを選択...
+dlgSaveOutputFileAs=名前を付けて出漁を保存...
 dlgLanguageHashNoMatch=言語ファイルのハッシュが一致しません。プログラムの実行時には重要ではないので大したことではありませんが、言語が間違っている可能性があります。
-dlgUpdateFailedToCheck=更新確認に失敗しました。手動でチェックしますか？
+dlgUpdateFailedToCheck=更新確認に失敗しました。手動で確認しますか？
 dlgUpdateNoUpdateAvailable=更新はありません。\r\n\r\n現在のバージョン: {0}\r\n最新バージョン: {1}
 dlgUpdateNoBetaUpdateAvailable=ベータ版の更新はありません。\r\n\r\n現在のベータ版のバージョン: {0}\r\n最新のベータ版のバージョン: {1}
-dlgUpdateNoValidYoutubeDl=ダウンロードまたは更新する有効な youtube-dl が見つかりませんでした。
-dlgUpdatedYoutubeDl=Youtube-dlの更新が完了しました。
-dlgUpateYoutubeDlNoUpdateRequired=Youtube-dlは、現時点では更新の必要はありません。\r\n\r\n現在のバージョン: {0}\r\n最新バージョン: {1}
+dlgUpdateNoValidYoutubeDl=ダウンロードまたは更新するための有効な youtube-dl が見つかりませんでした。
+dlgUpdatedYoutubeDl=Youtube-dl の更新が完了しました。
+dlgUpateYoutubeDlNoUpdateRequired=Youtube-dl は、現時点では更新の必要はありません。\r\n\r\n現在のバージョン: {0}\r\n最新バージョン: {1}
 dlgUpdaterHashNoMatch=アップデータのハッシュが内部に知られているハッシュと一致しません。それでも動作する可能性はありますが…。とにかく更新しますか？
 
-dlgUpdaterUpdatedVersionHashNoMatch=アップデータが計算したハッシュが既知のハッシュと一致しません。\r\n\r\n期待されたハッシュ値: {0}\r\n\r\n実際のハッシュ値: {1}\r\n\r\n一致しなくても続けられますが、異なる場合もあります。
-dlgUpdaterHashNotGiven=アップデートハッシュ値が設定されていないので、リリース時のものであることを健全性チェックするためにハッシュ値を計算できません。あなたのマイレージが変わるかもしれません。
+dlgAuthenticationCookiesFromBrowser=クッキーを読み込むブラウザー名。キーリング、ブラウザーのプロファイル、コンテナ（FireFoxを使用）も含むことができます。yt-dlp の readme - BROWSER[+KEYRING][:PROFILE][::CONTAINER]\n\n現在対応するブラウザ: brave, chrome, chromium, edge, firefox, opera, safari, vivaldi.\n追加で、Linux 上で Chromium のクッキーを復号化するキーリング、クッキーを読み込むプロファイル名/パス、コンテナ名 (Firefox) (なしなら none) を区切ってし指定できます。\n既定では、最も最近アクセスされたプロファイルのすべてのコンテナが市威容されます。\n現在対応するキーリング: basictext, gnomekeyring, kwallet
 
-frmAbout=About
-lbAboutBody=youtube-dl by {0}\nyoutube-dl-gui by {1}\ndebug date {2}
+dlgUpdaterUpdatedVersionHashNoMatch=アップデータが計算したハッシュが既知のハッシュと一致しません。\r\n\r\n期待されたハッシュ値: {0}\r\n\r\n実際のハッシュ値: {1}\r\n\r\n一致しなくても続けられますが、異なる場合もあります。
+dlgUpdaterHashNotGiven=更新用のハッシュ値が設定されていないので、リリース時と同じか健全性を確認するためのハッシュ値を計算できません。利用価値は様々でしょう。
+
+frmFileNameSchemaHistory=ファイル名のスキーマの履歴を編集
+
+pbDownloadProgressFfmpegPostProcessing=ffmpeg 後処理中...
+pbDownloadProgressEmbeddingSubtitles=字幕 埋め込み中...
+pbDownloadProgressEmbeddingMetadata=メタデータ 埋め込み中...
+pbDownloadProgressMergingFormats=形式 結合中...
+pbDownloadProgressConverting=メディア 変換中...
+
+frmAbout=情報
+lbAboutBody=youtube-dl-gui 開発 {0}\nデバッグ日 {1}\nGithub リポジトリに問題を報告
 llbCheckForUpdates=更新確認
 
+frmArchiveDownloader=アーカイブのダウンロード
+lbArchiveDownloaderDescription=削除された YouTube 動画が削除前にアーカイブされていたらダウンロードします。
+txtArchiveDownloaderHint=YouTube の URL か動画 id を入力
+
 frmAuthentication=認証
-lbAuthNotice=認証情報を入力してください:
+lbAuthNotice=認証情報を入力:
 lbAuthUsername=ユーザー名
 lbAuthPassword=パスワード
-lbAuth2Factor=2-Factor
-lbAuthVideoPassword=動画パスワード
-chkAuthUseNetrc=認証に .netrc を使用する
-lbAuthNoSave=セキュリティ上の理由によりあなたの情報は保存されません
+lbAuth2Factor=2段階認証
+lbAuthVideoPassword=動画のパスワード
+lbAuthCookiesFromFile=ファイルのクッキー
+lbAuthCookiesFromBrowser=ブラウザのクッキー
+chkAuthUseNetrc=認証に .netrc を使用
+lbAuthNoSave=セキュリティのためこの情報は保存されません
 btnAuthBeginDownload=ダウンロード開始
 
 frmBatchConverter=一括変換ツール
@@ -85,28 +98,28 @@ lbBatchConverterInput=入力ファイル
 txtBatchConverterInputFile=変換するファイル...
 lbBatchConverterOutput=出力ファイル
 txtBatchConverterOutputFile=作成するファイル...
-txtBatchConverterCustomConversionArguments=カスタム引数（デフォルトは空欄）
+txtBatchConverterCustomConversionArguments=カスタム引数（空にすると既定値）
 sbBatchConverterIdle=一括変換の開始を待機中
 sbBatchConverterConverting=一括変換中...
-sbBatchConverterFinished=一括変換が完了しました。ファイルを追加して別のバッチを開始するか、終了します。
-sbBatchConverterAborted=一括変換を中止しました。
+sbBatchConverterFinished=一括変換が完了。ファイルを追加し別の一括処理を開始、または終了します。
+sbBatchConverterAborted=一括変換を中止しました
 
 frmBatchDownload=一括ダウンロード
 lbBatchDownloadLink=ダウンロードURL
-lbBatchDownloadType=ダウンロードの種類
+lbBatchDownloadType=ダウンロード種別
 lbBatchDownloadVideoSpecificArgument=動画固有の引数
 sbBatchDownloadLoadArgs=引数を読込
 mBatchDownloaderLoadArgsFromSettings=設定から引数を読込
-mBatchDownloaderLoadArgsFromArgsTxt=./args.txtから引数を読込
+mBatchDownloaderLoadArgsFromArgsTxt=./args.txt から引数を読込
 mBatchDownloaderLoadArgsFromFile=ファイルから引数を読込..
 sbBatchDownloaderImportLinks=URLを読込...
 mBatchDownloaderImportLinksFromFile=ファイルからURLを読込
 mBatchDownloaderImportLinksFromClipboard=クリップボードからURLを読込
-sbBatchDownloaderIdle=一括ダウンロードの開始を待機しています
+sbBatchDownloaderIdle=一括ダウンロードの開始を待機中
 sbBatchDownloaderDownloading=一括ダウンロード中...
-sbBatchDownloaderFinished=一括ダウンロードが完了しました。さらにアイテムを追加して別のバッチを開始するか、終了します
+sbBatchDownloaderFinished=一括ダウンロードが完了。項目を追加し別の一括処理を開始、または終了します
 sbBatchDownloaderAborted=一括ダウンロードを中止しました
-chkBatchDownloadClipboardScanner=Scan clipboard
+chkBatchDownloadClipboardScanner=クリップボードを監視
 
 frmConverter=変換中
 frmConverterComplete=変換完了
@@ -117,66 +130,100 @@ btnConverterAbortBatchConversions=一括変換中止
 frmDownloader=ダウンロード中
 frmDownloaderComplete=ダウンロード完了
 frmDownloaderError=ダウンロードエラー
-chkDownloaderCloseAfterDownload=ダウンロード終了後閉じる
+chkDownloaderCloseAfterDownload=ダウンロード後閉じる
 
 frmDownloadLanguage=言語ファイルをダウンロード...
 
-frmException=エラーが発生しました
+frmException=エラーが発生
 lbExceptionHeader=エラーが発生しました
-lbExceptionDescription=以下が発生したエラーです。新しくIssueを開き報告してください。
-rtbExceptionDetails=テキスト全体をコピーしてGithubの新しいIssueに貼り付けてください。
-btnExceptionGithub=Githubを開く
+lbExceptionDescription=以下が発生したエラーです。新しく Issue を開き報告してください。
+rtbExceptionDetails=テキスト全体をコピーしてGithubの新しい Issue に貼り付けてください
+btnExceptionGithub=Github 開く
+tabExceptionDetails=エラーの詳細
+tabExceptionExtraInfo=追加の情報
+
+frmExtendedDownloaderRetrieving=データ取得中... - {0}
+lbExtendedDownloaderLink=リンク
+lbExtendedDownloaderUploader=アップロード者
+lbExtendedDownloaderViews=再生回数
+lbExtendedDownloaderDownloadingThumbnail=サムネイルのダウンロード中...
+lbExtendedDownloaderDownloadingThumbnailFailed=サムネイルをダウンロードできません
+btnExtendedDownloaderDownloadThumbnail=サムネイルを取得
+tabExtendedDownloaderUnknownFormats=不明の形式
+tabExtendedDownloaderDescription=説明
+tabExtendedDownloaderVerbose=詳細ログ
+tabExtendedDownloaderFormatOptions=形式オプション
+chkExtendedDownloaderVideoSeparateAudio=動画から音声を分離
+chContainer=コンテナ
+chFileSize=ファイルサイズ
+chFormatId=ID
+chVideoQuality=品質
+chVideoFPS=FPS
+chVideoBitrate=動画ビットレート
+chVideoDimension=動画サイズ
+chVideoCodec=動画コーデック
+chAudioBitrate=音声ビットレート
+chAudioSampleRate=音声サンプルレート
+chAudioCodec=音声コーデック
+chAudioChannels=音声チャンネル
+lbExtendedDownloaderNoVideoFormatsAvailable=動画形式が利用できません。
+lbExtendedDownloaderNoAudioFormatsAvailable=音声形式が利用できません。
+lbExtendedDownloaderNoUnknownFormatsFound=不明な形式はありません。
+lbVideoRemux=動画 Remux
+txtExtendedDownloaderMediaTitle=メディアの情報取得中...
 
 frmLanguage=言語の選択
 btnLanguageRefresh=更新
 btnLanguageDownload=ダウンロード...
+
+frmLog=ログ
+frmLogClear=消去
 
 frmMain=youtube-dl-gui
 mSettings=設定
 mTools=ツール
 mBatchDownload=一括ダウンロード
 mBatchConvert=一括変換
+mArchiveDownloader=アーカイブのダウンロード
 mDownloadSubtitles=字幕のダウンロード
 mMiscTools=その他のツール
-mClipboardAutoDownload=クリップボード自動ダウンロード
+mClipboardAutoDownload=クリップボードから自動ダウンロード
 mHelp=ヘルプ
 mLanguage=言語
 mSupportedSites=対応サイト
-mAbout=About
+mAbout=情報
 tabDownload=ダウンロード
 tabConvert=変換
 tabMerge=結合
 lbURL=URL
-txtUrlHint=動画URL
+txtUrlHint=動画の URL
 gbDownloadType=ダウンロードの種類
 lbQuality=品質
 lbFormat=形式
-chkDownloadSound=音声
-chkUseSelection=動画選択
-rbVideoSelectionPlaylistIndex=Playlist index
-rbVideoSelectionPlaylistItems=Playlist items
-rbVideoSelectionBeforeDate=Before date
-rbVideoSelectionOnDate=On date
-rbVideoSelectionAfterDate=After date
-txtPlaylistStartHint=Start index
-txtPlaylistEndHint=End index
-txtPlaylistItemsHint=Video indexes (separated by commas)
+chkUseSelection=動画を選択
+rbVideoSelectionPlaylistIndex=再生リスト index
+rbVideoSelectionPlaylistItems=再生リストの項目
+rbVideoSelectionBeforeDate=日付以前
+rbVideoSelectionOnDate=指定日
+rbVideoSelectionAfterDate=日付以降
+txtPlaylistStartHint=開始 index
+txtPlaylistEndHint=終了 index
+txtPlaylistItemsHint=動画 index (カンマ区切り)
 txtVideoDateHint=日付 (YYYYMMDD)
 lbCustomArguments=カスタム引数
-txtArgsHint=youtube-dlのカスタム引数
 sbDownload=ダウンロード
-mDownloadWithAuthentication=認証情報を入力してダウンロード...
+btnMainExtended=詳細...
+mDownloadWithAuthentication=認証情報でダウンロード...
 mBatchDownloadFromFile=ファイルから一括ダウンロード...
-msgBatchDownloadFromFile=テキストファイルを作成し、ダウンロードしたい動画のリンクを1行ごとに入力してください。\nこのオプションを使って一括ダウンロードをする際に、このメッセージを表示しないようにしますか？
-lbDownloadStatusStarted=ダウンロードを開始しました
-lbDownloadStatusError=ダウンロードエラー
+msgBatchDownloadFromFile=テキストファイルを作成し、ダウンロードしたい動画のリンクを1行ごとに記載してください。\nこのオプションから一括ダウンロードする際に、このメッセージを表示しないようにしますか？
+mQuickDownloadForm=クイックダウンロード
+mQuickDownloadFormAuthentication=クイックダウンロード (認証)
+mExtendedDownloadForm=詳細ダウンロード
 lbConvertInput=入力
 lbConvertOutput=出力
 rbConvertAuto=自動
 rbConvertAutoFFmpeg=自動 ffmpeg
 btnConvert=変換
-lbConvertStarted=変換を開始しました
-lbConvertFailed=変換が失敗しました
 lbMergeInput1=入力 1
 lbMergeInput2=入力 2
 lbMergeOutput=出力
@@ -190,7 +237,7 @@ cmTrayDownloadBestVideo=最高の動画をダウンロード
 cmTrayDownloadBestAudio=最高の音声をダウンロード
 cmTrayDownloadCustom=カスタムダウンロード...
 cmTrayDownloadCustomTxtBox=テキストボックスから
-cmTrayDownloadCustomTxt=./args.txtから
+cmTrayDownloadCustomTxt=./args.txt から
 cmTrayDownloadCustomSettings=設定から
 cmTrayConverter=変換...
 cmTrayConvertTo=変換します...
@@ -202,66 +249,76 @@ cmTrayConvertAutoFFmpeg=自動 ffmpeg
 cmTrayExit=終了
 
 frmSettings=youtube-dl-gui 設定
-btnSettingsRedownloadYoutubeDl=youtube-dlの再DL
-btnSettingsRedownloadYoutubeDlHint=dlが既に存在する場合は再ダウンロードして、それ以外の場合は更新します
-btnSettingsCancelHint=変更した設定を破棄します
-btnSettingsSaveHint=設定した内容を全て保存します
+btnSettingsCancelHint=変更した設定を破棄
+btnSettingsSaveHint=設定した内容をすべて保存
 tabSettingsGeneral=一般
 tabSettingsDownloads=ダウンロード
 tabSettingsConverter=動画変換
 tabSettingsExtensions=拡張子
 tabSettingsErrors=エラー
-tabSettingsPortable=ポータブル
-lbSettingsGeneralYoutubeDlPath=youtube-dlのパス
-chkSettingsGeneralUseStaticYoutubeDl=静的なyoutube-dlを使用
-txtSettingsGeneralYoutubeDlPathHint=youtube-dlの移動されないパス
-btnSettingsGeneralBrowseYoutubeDlHint=youtube-dlを保存する新しいフォルダを参照します
+tabSettingsGeneralYoutubeDl=youtube-dl
+tabSettingsGeneralFfmpeg=ffmpeg
+lbSettingsGeneralYoutubeDlPath=使用する dl のパス
+chkSettingsGeneralUseStaticYoutubeDl=固定した youtube-dl を使用
+txtSettingsGeneralYoutubeDlPathHint=youtube-dl のパス
+btnSettingsGeneralBrowseYoutubeDlHint=youtube-dl を保存する新しいフォルダを参照
 lbSettingsGeneralFFmpegDirectory=ffmpegのフォルダ
-chkSettingsGeneralUseStaticFFmpeg=静的なffmpegを使用
-txtSettingsGeneralFFmpegPathHint=ffmpegの移動されないパス
-btnSettingsGeneralBrowseFFmpegHint=ffmpegを保存する新しいフォルダを参照します
+chkSettingsGeneralUseStaticFFmpeg=固定した ffmpeg を使用
+txtSettingsGeneralFFmpegPathHint=ffmpeg のパス
+btnSettingsGeneralBrowseFFmpegHint=ffmpeg を保存する新しいフォルダを参照
+btnSettingsRedownloadYoutubeDl=youtube-dl の(再)ダウンロード
+btnSettingsRedownloadFfmpeg=ffmpeg の(再)ダウンロード
 chkSettingsGeneralCheckForUpdatesOnLaunch=起動時に更新を確認
 chkSettingsGeneralCheckForBetaUpdates=ベータ版の更新を確認
 chkSettingsGeneralDeleteUpdaterAfterUpdating=アップデート後に削除
-chkSettingsGeneralDeleteUpdaterAfterUpdatingHint=youtube-dl-guiアップデータが正常にアップデートされると削除されます。
+chkSettingsGeneralDeleteUpdaterAfterUpdatingHint=youtube-dl-gui アップデータが更新に成功すると削除されます。
 chkDeleteOldVersionAfterUpdating=アップデート後に古いバージョンを削除
 chkDeleteOldVersionAfterUpdatingHint=アップデートに成功すると、古いバージョンの youtube-dl-gui を削除します。
 chkSettingsGeneralHoverOverUrlToPasteClipboard=URLにカーソルを合わせるとクリップボードを自動貼り付け
 chkSettingsGeneralClearUrlOnDownload=ダウンロード時にURLを消去
 chkSettingsGeneralClearClipboardOnDownload=ダウンロード時にクリップボードの中身を消去
-gbSettingsGeneralCustomArguments=カスタム引数(ダウンロード時に保存)
+chkSettingsGeneralAutoUpdateYoutubeDl=起動時に youtube-dl を自動更新
+gbSettingsGeneralCustomArguments=カスタム引数 (ダウンロード時に保存)
 rbSettingsGeneralCustomArgumentsDontSave=保存しない
-rbSettingsGeneralCustomArgumentsSaveAsArgsText=./args.txtに保存
+rbSettingsGeneralCustomArgumentsSaveAsArgsText=./args.txt に保存
 rbSettingsGeneralCustomArgumentsSaveInSettings=設定に保存
 
-lbSettingsGeneralYoutubeDlPathHint=静的なyoutube-dlの保存フォルダ\n\n静的なyoutube-dlとは常に1つのフォルダに配置されることを意味します。
-chkSettingsGeneralUseStaticYoutubeDlHint=静的に配置されたyoutube-dl.exeを使用します
-ofdTitleYoutubeDl=youtube-dl.exeの選択
-ofdFilterYoutubeDl=youtube-dlの実行可能ファイル
-lbSettingsGeneralFFmpegDirectoryHint=静的なffmpegの保存フォルダ\n\n静的なffmpegとは常に1つのフォルダに配置されることを意味します。
-chkSettingsGeneralUseStaticFFmpegHint=静的に配置されたffmpeg.exeとffprobe.exeを使用します
-ofdTitleFFmpeg=ffmpeg.exeとffprobe.exeの選択
-ofdFilterFFmpeg=ffmpegとffprobeの実行可能ファイル
-chkSettingsGeneralCheckForUpdatesOnLaunchHint=youtube-dl-guiの起動時に更新を確認します
-chkSettingsGeneralCheckForBetaUpdatesHint=通常のアップデートではなくベータ版のアップデートを確認します
+lbSettingsGeneralYoutubeDlPathHint=静的な youtube-dl の保存フォルダ\n\n静的な youtube-dl とは、常に1つのフォルダに配置されることを意味します。
+chkSettingsGeneralUseStaticYoutubeDlHint=静的に配置した youtube-dl.exe を使用
+ofdTitleYoutubeDl=youtube-dl.exe の選択
+ofdFilterYoutubeDl=youtube-dl 実行ファイル
+lbSettingsGeneralFFmpegDirectoryHint=静的な ffmpeg の保存フォルダ\n\n静的な ffmpeg とは、常に1つのフォルダに配置されることを意味します。
+chkSettingsGeneralUseStaticFFmpegHint=静的に配置した ffmpeg.exe とffprobe.exe を使用
+ofdTitleFFmpeg=ffmpeg.exe と ffprobe.exe の選択
+ofdFilterFFmpeg=ffmpeg/ffprobe 実行ファイル
+btnSettingsRedownloadYoutubeDlHint=youtube-dl のパスが既にあれば更新。またはプログラムと同じフォルダにダウンロード。\n\nyoutube-dl のパスがアクセスまたは書き込み可能でないなら、ダウンロードは失敗します。
+btnSettingsRedownloadFfmpegHint=ffmpeg のパスが既にあれば最新版をダウンロードし展開。またはプログラムと同じフォルダにダウンロード。\n\nffmpeg のパスがアクセスまたは書き込み可能でないなら、ダウンロードは失敗します。
+chkSettingsGeneralCheckForUpdatesOnLaunchHint=youtube-dl-gui の起動時に更新を確認します
+chkSettingsGeneralCheckForBetaUpdatesHint=通常の最新版ではなくベータ版の更新を確認します
 chkSettingsGeneralHoverOverUrlToPasteClipboardHint=URLにカーソルを合わせるとクリップボードの中身を自動で貼りつけます
 chkSettingsGeneralClearUrlOnDownloadHint=ダウンロード時にテキストボックスのURLを消去します
 chkSettingsGeneralClearClipboardOnDownloadHint=ダウンロード時にクリップボードの中身を消去します
-gbSettingsGeneralCustomArgumentsHint=youtube-dlのカスタム引数がどのように保存されるかを制御します
+chkSettingsGeneralAutoUpdateYoutubeDlHint=youtube-dl-gui の起動時に youtube-dl または派生版を自動更新します。
+gbSettingsGeneralCustomArgumentsHint=youtube-dl のカスタム引数がどのように保存されるかを制御します
 rbSettingsGeneralCustomArgumentsDontSaveHint=カスタム引数を保存しません
-rbSettingsGeneralCustomArgumentsSaveAsArgsTextHint=カスタム引数をargs.txtとしてyoutube-dl-guiのディレクトリに保存します
-rbSettingsGeneralCustomArgumentsSaveInSettingsHint=アプリケーション設定にカスタム引数を保存します
-lbSettingsDownloadsDownloadPath=ダウンロード保存場所
+rbSettingsGeneralCustomArgumentsSaveAsArgsTextHint=カスタム引数を args.txt として youtube-dl-gui のフォルダに保存します
+rbSettingsGeneralCustomArgumentsSaveInSettingsHint=アプリケーションの設定にカスタム引数を保存します
+lbSettingsDownloadsDownloadPath=ダウンロードの保存場所
 txtSettingsDownloadsSavePathHint=ダウンロードしたファイルが保存される場所
 btnSettingsDownloadsBrowseSavePathHint=新しい保存場所を参照します
 lbSettingsDownloadsFileNameSchema=ファイル名のスキーマ
+btnSettingsDownloadsFileNameSchemaHistory=履歴
+btnSettingsDownloadsInstallProtocolNotInstalled=ブラウザのプロトコル インストール
+btnSettingsDownloadsInstallProtocolInstalled=ブラウザプロトコル インストール済み
+btnSettingsDownloadsInstallProtocolHint=レジストリにキーが追加され、ブラウザがこのプログラムにデータを送ることができるようになります。このプログラムをインストールするには、管理者権限が必要です。
 
 tabDownloadsGeneral=一般
 tabDownloadsSorting=分類
-tabdownloadsFixes=修正
+tabDownloadsFixes=修正
 tabDownloadsConnection=接続
 tabDownloadsUpdating=更新
 tabDownloadsBatch=一括
+tabExtendedOptions=詳細ダウンロード
 
 chkSettingsDownloadsSaveFormatQuality=ダウンロード時に品質、形式、引数を保存
 chkSettingsDownloadsDownloadSubtitles=字幕をダウンロード
@@ -273,17 +330,19 @@ chkSettingsDownloadsKeepOriginalFiles=元のファイルを保持
 chkSettingsDownloadsSaveAnnotations=注釈を保存
 chkSettingsDownloadsSaveThumbnails=サムネイルを保存
 chkSettingsDownloadsEmbedThumbnails=サムネイルをファイルに埋め込む
-chkSettingsDownloadsAutomaticallyDeleteYoutubeDlWhenClosing=終了時にyoutube-dlを自動的に削除
+chkSettingsDownloadsAutomaticallyDeleteYoutubeDlWhenClosing=終了時に youtube-dl を自動的に削除
 chkSettingsDownloadsSeparateDownloadsToDifferentFolders=別々のフォルダに保存
-chkSettingsDownloadsSeparateIntoWebsiteUrl=Webサイトごとに分ける
-chkSettingsDownloadsFixVReddIt=v.redd.itの修正
+chkSettingsDownloadsSeparateIntoWebsiteUrl=サイトごとに分ける
+chkSettingsDownloadsWebsiteSubdomains=フォルダ名にサブドメインを使用
+chkSettingsDownloadsFixVReddIt=v.redd.it の修正
+chkSettingsDownloadsPreferFFmpeg=ffmpeg を第一選択
 chkSettingsDownloadsLimitDownload=ダウンロード速度制限
 lbSettingsDownloadsRetryAttempts=再試行回数
-chkSettingsDownloadsForceIpv4=IPv4を強制
-chkSettingsDownloadsForceIpv6=IPv6を強制
+chkSettingsDownloadsForceIpv4=IPv4 を強制
+chkSettingsDownloadsForceIpv6=IPv6 を強制
 chkSettingsDownloadsUseProxy=プロキシを使用
-chksettingsDownloadsUseYoutubeDlsUpdater=youtube-dl の内部アップデータを使用する
-lbSettingsDownloadsUpdatingYtdlType=Youtube-DL fork
+chksettingsDownloadsUseYoutubeDlsUpdater=youtube-dl の内部アップデータを使用
+lbSettingsDownloadsUpdatingYtdlType=Youtube-DL 派生版
 llbSettingsDownloadsYtdlTypeViewRepo=レポジトリ表示
 chkSettingsDownloadsSeparateBatchDownloads=一括ダウンロードの保存先を別々にする
 chkSettingsDownloadsAddDateToBatchDownloadFolders=ダウンロードフォルダに日付を入れる
@@ -291,23 +350,26 @@ chkSettingsDownloadsAddDateToBatchDownloadFolders=ダウンロードフォルダ
 lbSettingsDownloadsDownloadPathHint=ダウンロードファイルを保存する場所
 chkSettingsDownloadsDownloadPathUseRelativePathHint=プログラムの相対パスに保存します。\r\n\r\nチェックした場合、プログラムは保存パスを確認し、カレントディレクトリを基本パスとして使用します。\r\nカレントディレクトリ以外の場所で保存すると、フラグは設定されず、選択した場所に設定されます。
 lbSettingsDownloadsFileNameSchemaHint=ファイル名スキーマ\n\nこれは基本的にシーケンスを動画情報に置き換えて、カスタムファイル名にします。
+btnSettingsDownloadsFileNameSchemaHistoryHint=スキーマの一覧を修正するための簡単な履歴エディターを表示。
 llSettingsDownloadsSchemaHelpHint=サポートされている引数を表示するにはここをクリックしてください
-txtSettingsDownloadsFileNameSchemaHint=youtube-dlで使用されるファイル名スキーマ
+txtSettingsDownloadsFileNameSchemaHint=youtube-dl で使用されるファイル名スキーマ
 
 chkSettingsDownloadsSaveFormatQualityHint=ダウンロード時にメインフレームの品質選択、形式選択、カスタム引数を保存します
 chkSettingsDownloadsDownloadSubtitlesHint=利用可能な全ての字幕をダウンロードします\n利用可能な字幕がない場合、何もダウンロードしません
 chkSettingsDownloadsEmbedSubtitlesHint=ダウンロードした字幕をファイルに埋め込みます。\nmp4、webm、mkv形式のみ対応
-chkSettingsDownloadsSaveVideoInfoHint=動画情報を.info.jsonファイルに保存します
+chkSettingsDownloadsSaveVideoInfoHint=動画情報を .info.json ファイルに保存します
 chkSettingsDownloadsWriteMetadataToFileHint=動画のメタデータを出力ファイルに書き込みます
-chkSettingsDownloadsSaveDescriptionHint=動画の説明文を.descriptionファイルに書き込みます
-chkSettingsDownloadsKeepOriginalFilesHint=ダウンロードの元ファイルを保持します\nデフォルトではyoutube-dlは結合後にそれらを削除します
-chkSettingsDownloadsSaveAnnotationsHint=動画の注釈を.annotations.xmlファイルに保存します
+chkSettingsDownloadsSaveDescriptionHint=動画の説明文を .description ファイルに書き込みます
+chkSettingsDownloadsKeepOriginalFilesHint=ダウンロードの元ファイルを保持します\nデフォルトでは youtube-dl は結合後にそれらを削除します
+chkSettingsDownloadsSaveAnnotationsHint=動画の注釈を .annotations.xml ファイルに保存します
 chkSettingsDownloadsSaveThumbnailsHint=動画のサムネイルを保存します
-chkSettingsDownloadsEmbedThumbnailsHint=ダウンロードしたサムネイルをカバーアートとして出力ファイルに埋め込みます\nAtomicParsleyが必要です
-chkSettingsDownloadsAutomaticallyDeleteYoutubeDlWhenClosingHint=youtube-dl-guiを閉じるときにyoutube-dl.exeを自動的に削除します
+chkSettingsDownloadsEmbedThumbnailsHint=ダウンロードしたサムネイルをカバーアートとして出力ファイルに埋め込みます\nAtomicParsley が必要です
+chkSettingsDownloadsAutomaticallyDeleteYoutubeDlWhenClosingHint=youtube-dl-gui を閉じるときに youtube-dl.exe を自動的に削除します
 chkSettingsDownloadsSeparateDownloadsToDifferentFoldersHint=ダウンロードの種類に応じて、ダウンロードしたファイルをそれぞれのフォルダに分けます\n動画は <download directory>\Video になります\n音声は <download directory>\Audio になります\nカスタムは <download directory>\Custom になります
 chkSettingsDownloadsSeparateIntoWebsiteUrlHint=ダウンロードしたファイルはダウンロードパスに保存され、末尾にWebサイトのURLが追加されます\n例: C:\Users\YourName\Videos\youtube.com\Video.mp4
-chkSettingsDownloadsFixVReddItHint=ffmpegのHTTP Live Streaming (HLS)を使用してv.redd.it/reddit.comリンクの画像の乱れを修正します\nそのままにすることを推奨します。\nFFMPEGがインストールされて利用可能である必要があり、youtube-dlのデフォルトにフォールバックします。
+chkSettingsDownloadsWebsiteSubdomainsHint=サブドメインがあるサイトでダウンロードするとそれぞれのフォルダーに分けられます。\n例: C:\\Users\\YourName\\Videos\\mobile.youtube.com\\Video.mp4 (mobile が youtube.com のサブドメイン)
+chkSettingsDownloadsFixVReddItHint=ffmpeg の HTTP Live Streaming (HLS)を使用して v.redd.it/reddit.com リンクの画像の乱れを修正します\nそのままにすることを推奨します。\nFFMPEG がインストールされて利用可能である必要があり、youtube-dl のデフォルトにフォールバックします。
+chkSettingsDownloadsPreferFFmpegHint=youtube-dl のHLS (HTTP Live Streaming) より ffmpeg の HLS を優先します。あるサイトでは修正され、別のサイトでは壊れるでしょう。要試行錯誤。
 chkSettingsDownloadsLimitDownloadHint=ダウンロードを指定した速度に制限します
 numSettingsDownloadsLimitDownloadHint=ダウンロードする際の速度\n数値を0に設定すると、無制限になります
 cbSettingsDownloadsLimitDownloadHint=バイトサイズの制限
@@ -319,16 +381,20 @@ chkSettingsDownloadsUseProxyHint=プロキシを使用してダウンロード�
 cbSettingsDownloadsProxyTypeHint=使用するプロキシプロトコル
 txtSettingsDownloadsProxyIpHint=使用するプロキシIP
 txtSettingsDownloadsProxyPortHint=使用するプロキシポート
-chksettingsDownloadsUseYoutubeDlsUpdaterHint=このアプリケーションのアップデータの代わりにyoutube-dlの内部アップデータを使用します
-cbSettingsDownloadsUpdatingYtdlTypeHint=対象となるyoutube-dlのレポジトリ
+chksettingsDownloadsUseYoutubeDlsUpdaterHint=このアプリのアップデータの代わりに youtube-dl の内部アップデータを使用します
+cbSettingsDownloadsUpdatingYtdlTypeHint=対象とする youtube-dl のレポジトリ
 llbSettingsDownloadsYtdlTypeViewRepoHint=選択したフォークのレポジトリページへ移動します
 chkSettingsDownloadsSeparateBatchDownloadsHint=一括ダウンロードは、指定したダウンロードパスの新しいフォルダに分けられます
 chkSettingsDownloadsAddDateToBatchDownloadFoldersHint=一括ダウンロードは、バッチ開始日時によってさらに新しいフォルダに分けられます
+chkExtendedPreferExtendedDialog=詳細ダウンロードを第一選択
+chkExtendedPreferExtendedDialogHint=メインのフォームの「ダウンロード」をクリックすると、クイックダウンローダーではなく詳細ダウンロードを使用するようにします。
+chkExtendedAutomaticallyDownloadThumbnail=サムネイルを自動でダウンロード
+chkExtendedAutomaticallyDownloadThumbnailHint=表示される動画のサムネイルがあれば自動的にダウンロードします。
 
 chkSettingsConverterClearOutputAfterConverting=変換後に出力を消去
-chkSettingsConverterDetectOutputFileType=出力ファイルタイプを検出
+chkSettingsConverterDetectOutputFileType=出力するファイル種別を検出
 chkSettingsConverterClearInputAfterConverting=変換後に入力を消去
-chkSettingsConverterHideFFmpegCompileInfo=ffmpegのコンパイル情報を非表示
+chkSettingsConverterHideFFmpegCompileInfo=ffmpeg のコンパイル情報を非表示
 tcSettingsConverterVideo=動画
 tcSettingsConverterAudio=音声
 tcSettingsConverterCustom=カスタム
@@ -343,32 +409,29 @@ lbSettingsConverterCustomHeader=プログラムが自動で処理するため、
 chkSettingsConverterClearOutputAfterConvertingHint=変換が成功した後に出力ファイルを消去します
 chkSettingsConverterDetectOutputFileTypeHint=変換時に「自動」がチェックされている場合、出力ファイルの種類の検出しようとします。\nシンプルに変換したい場合は無効にしてください。結果的に品質が低下することがあります。
 chkSettingsConverterClearInputAfterConvertingHint=変換が成功した後に入力ファイルを消去します
-chkSettingsConverterHideFFmpegCompileInfoHint=有効にするとffmpegのコンパイル情報の一部が非表示になります
-lbSettingsConverterVideoBitrateHint=動画ビットレート\nビットレートとは、1秒間にプレイヤーへ送信されるビット数です。\n高い = 多くのファイル容量を必要とします。\nビットレートを「10,000」で入力すると、「10,000,000」ビットとして解釈されます。
-lbSettingsConverterVideoPresetHint=変換の動画プリセット\nultrafast = 最速ですが、低品質です\nveryslow = 最遅ですが高品質です
-lbSettingsConverterVideoProfileHint=変換中に使用されるエンコーダプロファイル。動画の圧縮率に影響します。\n一般的にはmainプロファイルを使用することを推奨します。
-lbSettingsConverterVideoCRFHint=CRFはconstant rate factorです\n低い = 高品質
-chkSettingsConverterVideoFastStartHint=Faststartはメタデータをファイルの先頭に移動します。\n有効にすると、完全にダウンロードされる前に動画を再生できます。
-lbSettingsConverterAudioBitrateHint=音声ビットレート\nビットレートとは、1秒間にプレイヤーへ送信されるビット数です。\n高い = 多くのファイル容量を必要とします。\nビットレートを「256」で入力すると、「256,000」ビットとして解釈されます。
-txtSettingsConverterCustomArgumentsHint=組み込み引数の代わりにffmpegに渡されるカスタム引数
-lbSettingsExtensionsHeader=このアプリケーションで使用する独自の拡張子を入力できます
-lbSettingsExtensionsExtensionFullName=拡張子の完全な名称
-txtSettingsExtensionsExtensionFullName=Example extension
+chkSettingsConverterHideFFmpegCompileInfoHint=有効にすると ffmpeg のコンパイル情報の一部が非表示になります
+lbSettingsConverterVideoBitrateHint=動画ビットレート\nビットレートとは、1秒間にプレイヤーへ送信されるビット数です。\n高い = 多くのファイル容量が必要。\nビットレートを「10,000」で入力すると、「10,000,000」ビットとして解釈されます。
+lbSettingsConverterVideoPresetHint=変換の動画プリセット\nultrafast = 最速で低品質\nveryslow = 最遅で高品質
+lbSettingsConverterVideoProfileHint=変換中に使用されるエンコーダプロファイル。動画の圧縮率に影響します。\n一般的には main プロファイルの使用を推奨します。
+lbSettingsConverterVideoCRFHint=CRF は constant rate factor です\n低い = 高品質
+chkSettingsConverterVideoFastStartHint=Faststart はメタデータをファイルの先頭に移動します。\n有効にすると、完全にダウンロードされる前に動画を再生できます。
+lbSettingsConverterAudioBitrateHint=音声ビットレート\nビットレートとは、1秒間にプレイヤーへ送信されるビット数です。\n高い = 多くのファイル容量が必要。\nビットレートを「256」で入力すると、「256,000」ビットとして解釈されます。
+txtSettingsConverterCustomArgumentsHint=組み込み引数の代わりに ffmpeg に渡されるカスタム引数
+lbSettingsExtensionsHeader=このアプリで使用する独自の拡張子を指定可能
+lbSettingsExtensionsExtensionFullName=拡張子の名前
+txtSettingsExtensionsExtensionFullName=拡張子の名前の例
 lbSettingsExtensionsExtensionShort=拡張子の短縮名
 txtSettingsExtensionsExtensionShort=ext
 btnSettingsExtensionsAdd=追加
 lbSettingsExtensionsFileName=ファイル名
-btnSettingsExtensionsRemoveSelected=選択項目の削除
+btnSettingsExtensionsRemoveSelected=選択項目削除
 
 chkSettingsErrorsShowDetailedErrors=エラーの詳細を表示
-chkSettingsErrorsSaveErrorsAsErrorLog=エラーを./error.logに保存
+chkSettingsErrorsSaveErrorsAsErrorLog=エラーを ./error.log に保存
 chkSettingsErrorsSuppressErrors=エラーの抑制
 chkSettingsErrorsShowDetailedErrorsHint=エラーの詳細を表示します
-chkSettingsErrorsSaveErrorsAsErrorLogHint=最新のエラーをyoutube-dlの実行フォルダにerror.logとして保存します
-chkSettingsErrorsSuppressErrorsHint=全てのエラーを抑制しerror.logファイルは保存されません。\nこれは基本的にすべてのエラー設定を上書きします。自己責任でご利用ください。
-
-lbSettingsPortableInformation=ポータブルなiniファイルを使用するか選択できます。\r\n\r\n有効にすると、youtube-dl-guiと同じフォルダ「setting.ini」ファイルに全ての設定が保存されます。\r\n\r\n他のシステムの設定をこのプログラムで使用したい場合に有効です。\r\n\r\niniファイルを移動すると、現在の設定が転送されます。
-chkSettingsPortableToggleIni=Toggle portable ini
+chkSettingsErrorsSaveErrorsAsErrorLogHint=最新のエラーを youtube-dl の実行フォルダに error.log として保存します
+chkSettingsErrorsSuppressErrorsHint=すべてのエラーを抑制し error.log ファイルは保存されません。\n再試行可能なエラーはこのオプションの対象外です。\n\nこれは基本的にすべてのエラー設定を上書きします。自己責任でご利用ください。
 
 frmSubtitles=字幕のダウンロード
 lbSubtitlesHeader=字幕のみダウンロード
@@ -383,26 +446,35 @@ btnMiscToolsRemoveAudio=音声の除去...
 btnMiscToolsExtractAudio=音声の抽出...
 btnMiscToolsVideoToGif=動画をGIFへ変換...
 
-frmUpdateAvailable=アップデート可能
+frmUpdateAvailable=更新あり
 lbUpdateAvailableHeader=更新が利用可能です
-lbUpdateAvailableUpdateVersion=更新バージョン:
-lbUpdateAvailableCurrentVersion=現在のバージョン:
+lbUpdateAvailableUpdateVersion=最新のバージョン: {0}
+lbUpdateAvailableCurrentVersion=現在のバージョン: {0}
 lbUpdateAvailableChangelog=変更履歴:
+lbUpdateSize=新しい実行ファイルのサイズ {0}
 btnUpdateAvailableSkipVersion=スキップ
 btnUpdateAvailableUpdate=更新
 
-frmUpdater=youtube-dl-guiの更新中
-lbUpdaterHeader=Placeholder
-lbUpdaterDetails=失敗しても前のバージョンは削除されません
-rtbUpdaterExceptionDetails=Feel free to copy + paste this entire text wall into a new issue on Github. The old youtube-dl-gui will be restored, and you can attempt to redownload the update through the application, or manually from Github.
+frmUpdaterInvalidData=更新データを利用できません
+lbUpdaterInvalidData=アップデーターが受信した更新データが正しくないです。以下から選択できます。最新版をダウンロード、存在すれば最新のプレリリース版をダウンロード、更新しない。
+btnUpdaterInvalidDataUpdateLatest=最新版
+btnUpdaterInvalidDataUpdatePreRelease=プレリリース版
+btnUpdaterInvalidDataDoNotUpdate=更新しない
+
+frmUpdater=youtube-dl-gui の更新
+lbUpdaterHeader=アップデーター
+lbUpdaterDetails=失敗しても前のバージョンは削除されません。
+rtbUpdaterExceptionDetails=Github の新しい issue へと、この文字列全体を自由にコピーし貼り付けてください。古い youtube-dl-gui が復元されます。本アプリを通じて、または Github から手動で更新を再ダウンロードできます。
+pbDownloadProgressWaitingForData=データの更新を待機中
+pbDownloadProgressWaitingForClose=プログラムの終了を待機中
 pbDownloadProgressPreparing=ダウンロードの準備
 pbDownloadProgressCalculatingHash=ハッシュの計算
 pbDownloadProgressHashNoMatch=ハッシュが一致しません
 pbDownloadProgressSkippingHashCalculating=ハッシュの計算をスキップ...
 pbDownloadProgressCancelled=中止
-pbDownloadProgressWebException=WEBの例外が発生しました
+pbDownloadProgressWebException=ウェブの例外が発生しました
 pbDownloadProgressDownloadException=例外が発生しました
 pbDownloadProgressErrorDownloading=ダウンロードエラー
-pbDownloadProgressDownloadTooSmall=エラー: ダウンロードが小さすぎます
+pbDownloadProgressDownloadTooSmall=エラー: ダウンロードファイルが小さすぎます
 pbDownloadProgressDownloadFinishedLaunching=ダウンロード完了 起動中...
 pbDownloadProgressErrorProcessingDownload=ダウンロード処理エラー


### PR DESCRIPTION
「日本語版の利用者へ : For Users of the Japanese version」
翻訳版に ``chkUseSelection`` のような内部文字列風の文字列があるなら、新しい文字列が追加されていません。English.ini の変更点を Japanese.ini に追加してください。この内部文字列が多い場合、翻訳でなくとも単に英語を追加するだけでも有用でしょう。

English.ini の変更履歴 : https://github.com/murrty/youtube-dl-gui/commits/master/Languages/English.ini

各変更を見るには、履歴から7桁のハッシュ文字列をクリックします（View commit details）。